### PR TITLE
Drop Node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node
 
-* [Node.js](https://nodejs.org/) - v10.0.0+
+* [Node.js](https://nodejs.org/) - v12.0.0+
 * [npm](https://www.npmjs.com/) - v6.0.0+
 
 ## Install project dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Thomas Lindner
+Copyright (c) 2020-2021 Thomas Lindner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ First thing first, let's make sure you have the necessary pre-requisites.
 
 #### Node
 
-* [Node.js](https://nodejs.org/) - v10.0.0+
+* [Node.js](https://nodejs.org/) - v12.0.0+
 * [npm](http://npmjs.com) - v6.0.0+
 
 ### Command
@@ -68,4 +68,4 @@ Please see the [CHANGELOG.md](CHANGELOG.md) for more information.
 
 ## License
 
-Copyright (c) 2020 Thomas Lindner. Licensed under the MIT license.
+Copyright (c) 2020-2021 Thomas Lindner. Licensed under the MIT license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-typescript-tc",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
       "dev": true
     },
     "@babel/core": {
@@ -80,26 +80,16 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.10.tgz",
-      "integrity": "sha512-/I1HQ3jGPhIpeBFeI3wO9WwWOnBYpuR0pX0KlkdGcRQAVX9prB/FCS2HBpL7BiFbzhny1YCiBH8MTZD2jJa7Hg==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+      "integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
       "dev": true,
       "requires": {
-        "eslint-scope": "5.1.0",
+        "eslint-scope": "^5.1.0",
         "eslint-visitor-keys": "^1.3.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "eslint-scope": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -128,12 +118,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.15",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -1318,9 +1308,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1481,9 +1471,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.22",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
-      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -2408,16 +2398,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001214",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.719",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -2433,6 +2423,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
       "dev": true
     },
     "cache-base": {
@@ -2486,9 +2482,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001199",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
-      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
+      "version": "1.0.30001216",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001216.tgz",
+      "integrity": "sha512-1uU+ww/n5WCJRwUcc9UH/W6925Se5aNnem/G5QaSDga2HzvjYMs8vRbekGUN/PnTZ7ezTHcxxTEb9fgiMYwH6Q==",
       "dev": true
     },
     "capture-exit": {
@@ -2938,9 +2934,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.687",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+      "version": "1.3.721",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.721.tgz",
+      "integrity": "sha512-7nGs30ff6+KQs1Xhhih0+d6LNq2xz7O+B2aeCiCjYGiYrIIIUntJNaZhPfySw5ydPvZq5IdOdxkEgemYGOSQPw==",
       "dev": true
     },
     "emittery": {
@@ -3276,13 +3272,13 @@
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew=="
     },
     "eslint-config-tc": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-18.1.0.tgz",
-      "integrity": "sha512-35a33ioewUZj/fMsrQoNdDvvBfBMYw3rcPhuJgB6I7yFQBJc4yscWZ9+HJVv3l1au43jskv5Oi16eNyZ97w9Jg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-19.0.0.tgz",
+      "integrity": "sha512-8tcjer7d9Iabq7r/mEVaDTdtRPZRIMfUFRoL8WYwsAI2yM1DD9u+8W9A5sULVeThOFdc7vU44ALXsA1rihML7w==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.2.1",
-        "eslint-config-prettier": "^8.1.0"
+        "eslint-config-prettier": "^8.3.0"
       }
     },
     "eslint-formatter-pretty": {
@@ -3534,26 +3530,33 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-28.0.2.tgz",
-      "integrity": "sha512-k4AoFP7n8/oq6lBXkdc9Flid6vw2B8j7aXFCxgzJCyKvmaKrCUFb1TFPhG9eSJQFZowqmymMPRtl8oo9NKLUbw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-31.0.0.tgz",
+      "integrity": "sha512-HR3gI4ANtV8A+0FLAaxjBD/G5J3PWBo+7OswyGeK5nylGqtKLJVbnPksIkBgmVg+SFpxu5MnjaxQQI+9KjyVAg==",
       "dev": true,
       "requires": {
-        "ci-info": "^2.0.0",
+        "ci-info": "^3.1.1",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.2.2",
+        "eslint-template-visitor": "^2.3.2",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "import-modules": "^2.1.0",
-        "lodash": "^4.17.20",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.22",
+        "regexp-tree": "^0.1.23",
         "reserved-words": "^0.1.2",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.4"
+        "semver": "^7.3.5"
       },
       "dependencies": {
+        "ci-info": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz",
+          "integrity": "sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==",
+          "dev": true
+        },
         "eslint-visitor-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
@@ -3578,6 +3581,12 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -3671,9 +3680,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -3745,36 +3754,35 @@
           }
         },
         "@babel/core": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-          "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+          "version": "7.13.16",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+          "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-compilation-targets": "^7.13.10",
-            "@babel/helper-module-transforms": "^7.13.0",
-            "@babel/helpers": "^7.13.10",
-            "@babel/parser": "^7.13.10",
+            "@babel/generator": "^7.13.16",
+            "@babel/helper-compilation-targets": "^7.13.16",
+            "@babel/helper-module-transforms": "^7.13.14",
+            "@babel/helpers": "^7.13.16",
+            "@babel/parser": "^7.13.16",
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
+            "@babel/traverse": "^7.13.15",
+            "@babel/types": "^7.13.16",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
             "semver": "^6.3.0",
             "source-map": "^0.5.0"
           }
         },
         "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+          "version": "7.13.16",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+          "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.0",
+            "@babel/types": "^7.13.16",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
@@ -3800,38 +3808,37 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-          "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+          "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.0"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+          "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-          "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+          "version": "7.13.14",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+          "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
           "dev": true,
           "requires": {
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-replace-supers": "^7.13.0",
-            "@babel/helper-simple-access": "^7.12.13",
+            "@babel/helper-module-imports": "^7.13.12",
+            "@babel/helper-replace-supers": "^7.13.12",
+            "@babel/helper-simple-access": "^7.13.12",
             "@babel/helper-split-export-declaration": "^7.12.13",
             "@babel/helper-validator-identifier": "^7.12.11",
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
-            "lodash": "^4.17.19"
+            "@babel/traverse": "^7.13.13",
+            "@babel/types": "^7.13.14"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -3844,24 +3851,24 @@
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-          "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+          "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.13.0",
+            "@babel/helper-member-expression-to-functions": "^7.13.12",
             "@babel/helper-optimise-call-expression": "^7.12.13",
             "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-          "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+          "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -3874,14 +3881,14 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-          "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+          "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
           "dev": true,
           "requires": {
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0"
+            "@babel/traverse": "^7.13.17",
+            "@babel/types": "^7.13.17"
           }
         },
         "@babel/highlight": {
@@ -3896,9 +3903,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+          "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
           "dev": true
         },
         "@babel/template": {
@@ -3913,30 +3920,28 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-          "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+          "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.0",
+            "@babel/generator": "^7.13.16",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.0",
-            "@babel/types": "^7.13.0",
+            "@babel/parser": "^7.13.16",
+            "@babel/types": "^7.13.17",
             "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+          "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -4014,23 +4019,6 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        }
-      }
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -4968,6 +4956,15 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
+      }
+    },
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
@@ -5606,9 +5603,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -8202,9 +8199,9 @@
       }
     },
     "npm-package-json-lint-config-tc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-4.0.0.tgz",
-      "integrity": "sha512-e6CFWeQyM6jw5eqb0Ds/7HFdyrySE7ZDbQ8BXS5zJEmcxg+heiCiX14ZSp3dCwDDXA5ZaMdgukOB5sNVU3k1Qw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-4.1.0.tgz",
+      "integrity": "sha512-P33rs7G6tYxKZSRWhPwJ4qBJC3rNyVA5iaAwX62jO5BGBUlrpj71YsC3zjIx/smpFa7aAKvgzWUwSLY9MI2Psw==",
       "dev": true
     },
     "npm-run-path": {
@@ -8394,9 +8391,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
           "dev": true
         },
         "object.assign": {
@@ -9963,15 +9960,23 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.0",
-        "has-symbols": "^1.0.0",
-        "which-boxed-primitive": "^1.0.1"
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-typescript-tc",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "ESLint shareable config for TypeScript projects",
   "keywords": [
     "eslintconfig",
@@ -35,20 +35,20 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.22",
+    "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "eslint": "^7.25.0",
-    "eslint-config-tc": "^18.1.0",
+    "eslint-config-tc": "^19.0.0",
     "eslint-formatter-pretty": "^4.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-unicorn": "^28.0.2",
+    "eslint-plugin-unicorn": "^31.0.0",
     "is-plain-obj": "^3.0.0",
     "jest": "^26.6.3",
     "npm-package-json-lint": "^5.1.0",
-    "npm-package-json-lint-config-tc": "^4.0.0",
+    "npm-package-json-lint-config-tc": "^4.1.0",
     "prettier": "^2.2.1",
     "typescript": "^4.2.4"
   },
@@ -61,7 +61,7 @@
     "eslint": "^7.0.0"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=12.0.0",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Release notes

### 💥 Breaking changes
- Drop support for Node 10

### 🧹 Chores
- Bump @typescript-eslint/eslint-plugin from 4.18.0 to 4.19.0 (#88)
- Bump @typescript-eslint/parser from 4.18.0 to 4.19.0 (#87)
- Bump @types/jest from 26.0.21 to 26.0.22 (#89)
- Bump eslint from 7.22.0 to 7.23.0 (#90)
- Bump @typescript-eslint/parser from 4.19.0 to 4.20.0 (#91)  
- Bump @typescript-eslint/eslint-plugin from 4.19.0 to 4.20.0 (#92)  
- Bump eslint-plugin-jest from 24.3.2 to 24.3.4 (#93)
- Bump @typescript-eslint/eslint-plugin from 4.20.0 to 4.21.0 (#95)
- Bump @typescript-eslint/parser from 4.20.0 to 4.21.0 (#94)  
- Bump typescript from 4.2.3 to 4.2.4 (#96)
- Bump eslint-plugin-jest from 24.3.4 to 24.3.5 (#98)  
- Bump eslint from 7.23.0 to 7.24.0 (#97)  
- Bump @typescript-eslint/parser from 4.21.0 to 4.22.0 (#100)
- Bump @typescript-eslint/eslint-plugin from 4.21.0 to 4.22.0 (#99)
- Bump eslint-config-prettier from 8.1.0 to 8.2.0 (#101)
- Bump eslint-plugin-prettier from 3.3.1 to 3.4.0 (#102)  
- Bump eslint from 7.24.0 to 7.25.0 (#106)  
- Bump eslint-plugin-jest from 24.3.5 to 24.3.6 (#105)  
- Bump eslint-config-prettier from 8.2.0 to 8.3.0 (#104) 